### PR TITLE
indicate that key file name is needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ docker run -d --name=ssh-agent whilp/ssh-agent:latest
 Then, run a temporary container which has access to both the volumes from the long-lived `ssh-agent` container as well as a volume mounted from your host that includes your SSH keys. This container will only be used to load the keys into the long-lived `ssh-agent` container. Run the following command once for each key you wish to make available through the `ssh-agent`:
 
 ```console
-docker run --rm --volumes-from=ssh-agent -v ~/.ssh:/ssh -it whilp/ssh-agent:latest ssh-add /ssh/
+docker run --rm --volumes-from=ssh-agent -v ~/.ssh:/ssh -it whilp/ssh-agent:latest ssh-add /ssh/<host_key_file_name>
 ```
 
 Now, other containers can access the keys via the `ssh-agent` by setting the `SSH_AUTH_SOCK` environment variable:


### PR DESCRIPTION
After a bit of confusion, I focused and realized I only needed the keyfile name from the host `~/.ssh/` to make this work...
