### PR TITLE
Remove socket if it exists; don't redirect output

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -3,7 +3,8 @@
 case "$1" in
     ssh-agent)
         # NOTE: openssh 6.9 introduces -D for running ssh-agent in the foreground.
-        exec /usr/bin/ssh-agent -a ${SSH_AUTH_SOCK} -d > /dev/null 2>&1
+        [[ -e ${SSH_AUTH_SOCK} ]] && rm ${SSH_AUTH_SOCK}
+        exec /usr/bin/ssh-agent -a ${SSH_AUTH_SOCK} -d
         ;;
     *)
         exec $@;;


### PR DESCRIPTION
When stopping container socket file will be left on filesystem, starting
container again will make ssh-agent fail as it can't bind to existing path.
Following error was printed in this case:

```
$ docker-compose logs ssh-agent
Attaching to uxpindocker_ssh-agent_1
ssh-agent_1 | bind: Address in use
ssh-agent_1 | unix_listener: cannot bind to path: /root/.ssh/socket
```

To get this error I had to disable output redirection in run.sh, I think
it shouldn't be disabled as there there is no way to debug.
