### PR TITLE
Fix invalid command

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ SSH_AUTH_SOCK=/ssh/auth/sock
 ### List Keys
 
 ```console
-docker run --rm -it -v ssh:/ssh -e SSH_AUTH_SOCK=/ssh/auth/sock ubuntu /bin/bash -c "apt-get install -y openssh-client && ssh-add -l"
+docker run --rm -it -v ssh:/ssh -e SSH_AUTH_SOCK=/ssh/auth/sock ubuntu /bin/bash -c "apt-get update && apt-get install -y openssh-client && ssh-add -l"
 ```
 
 ## Notes


### PR DESCRIPTION
When running `apt-get` install without ever calling `apt-get update` you won't find the package.

@whilp 
